### PR TITLE
running securityhub sync on schedule

### DIFF
--- a/.github/workflows/security-hub-sync.yml
+++ b/.github/workflows/security-hub-sync.yml
@@ -1,14 +1,9 @@
 name: Security Hub Sync
 
 on:
-  push:
-    branches:
-      - "*"
-      - "!skipci*"
-
-  #schedule:
-  #   - cron: "0 0 * * *" # At 12am everyday
-  # workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # At 12am everyday
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref_name }}-group


### PR DESCRIPTION
## Purpose

This PR is to run security hub sync workflow on cron schedule(every day at 12 AM). Securityhub findings sync was implemented in the seatool-connector repo to run on push. We want to run it on schedule instead.



## Approach

This change runs the securityhub sync workflow on schedule


#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] I updated the architecture diagram if applicable
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
