### PR TITLE
Add error handling on http.request

### DIFF
--- a/src/libs/connect-lib.js
+++ b/src/libs/connect-lib.js
@@ -37,12 +37,16 @@ export async function connectRestApiWithRetry(params) {
           console.log(d.toString("utf-8"));
         })
         .on("error", (error) => {
-          console.log(error.toString("utf-8"));
+          console.log("res.on error:", error);
           retry.call(`${error}`);
         })
         .on("end", (d) => {
           resolver(req, resolve);
         });
+    });
+    req.on("error", (error) => {
+      console.log("req.on error:", error);
+      reject(error);
     });
     if (params.body) {
       req.write(JSON.stringify(params.body));
@@ -113,11 +117,16 @@ export async function deleteConnector(ip, name) {
           }
         })
         .on("error", (error) => {
+          console.log("res.on error:", error);
           return retry.call(`${error}`);
         })
         .on("end", (d) => {
           resolver(req, resolve);
         });
+    });
+    req.on("error", (error) => {
+      console.log("req.on error:", error);
+      reject(error);
     });
     req.write(JSON.stringify({}));
     req.end();
@@ -153,14 +162,17 @@ export async function testConnector(ip, config) {
           resolve(data);
         })
         .on("error", (error) => {
-          console.log(error);
+          console.log("res.on error:", error);
           reject(error);
         })
         .on("end", (d) => {
           resolver(req, resolve);
         });
     });
-
+    req.on("error", (error) => {
+      console.log("req.on error:", error);
+      reject(error);
+    });
     req.write(JSON.stringify({}));
     req.end();
   });


### PR DESCRIPTION
## Purpose

Update our http requests code to handle an error thrown on the req object.

#### Linked Issues to Close

https://qmacbis.atlassian.net/browse/OY2-21920

## Approach

Added handling for req.on("error")

## Learning

https://stackoverflow.com/a/8381820/1260955

## Assorted Notes/Considerations

We were handling res.on("error"), but not req.on("error") which is not the same.

#### Pull Request Creator Checklist

- [x] This PR has an associated issue or issues.
- [x] The associated issue(s) are linked above.
- [x] This PR meets all acceptance criteria for those issues.
- [x] This PR and linked issue(s) are adequately documented
- [x] I updated the architecture diagram if applicable
- [x] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [x] Someone has been assigned this PR.
- [x] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
