### PR TITLE
Added CloudWatch and Event Bridge Policy to KMS

### DIFF
--- a/src/services/alerts/serverless.yml
+++ b/src/services/alerts/serverless.yml
@@ -54,6 +54,23 @@ resources:
                 - "kms:GenerateDataKey"
                 - "kms:Decrypt"
               Resource: "*"
+            - Sid: Allow CloudWatch events to use the key
+              Effect: Allow
+              Principal:
+                Service: events.amazonaws.com
+              Action:
+                - "kms:Decrypt"
+                - "kms:GenerateDataKey"
+              Resource: "*"
+            - Sid: Allow CloudWatch for CMK
+              Effect: Allow
+              Principal:
+                Service:
+                  - cloudwatch.amazonaws.com
+              Action:
+                - "kms:Decrypt"
+                - "kms:GenerateDataKey*"
+              Resource: "*"
 
     EventBridgeToToSnsPolicy:
       Type: AWS::SNS::TopicPolicy


### PR DESCRIPTION
## Purpose
We needed to create kms keys to encrypt unencrypted sns topics 

#### Linked Issues to Close

Closes #53 

## Approach

This change encrypts the sns topic created from this repo. The policy allows access to Cloud watch and Event Bridge  


#### Pull Request Creator Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] I updated the architecture diagram if applicable
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
- [ ] Someone has been assigned this PR.
- [ ] At least one person has been marked as reviewer on this PR.

#### Pull Request Reviewer/Assignee Checklist

- [ ] This PR has an associated issue or issues.
- [ ] The associated issue(s) are linked above.
- [ ] This PR meets all acceptance criteria for those issues.
- [ ] This PR and linked issue(s) are adequately documented
- [ ] This PR and linked issues(s) are a complete description of the changeset; an individual or team should be able to understand the issue(s) and changes by reading through this PR and it's links, with no further interaction.
