### PR TITLE
fix(deleteTopics timeout):  Increase deleteTopics timeout to prevent failure

### DIFF
--- a/src/libs/topics-lib.js
+++ b/src/libs/topics-lib.js
@@ -126,6 +126,7 @@ export async function deleteTopics(brokerString, topicList) {
   console.log(`Deleting topics:  ${topicsToDelete}`);
   await admin.deleteTopics({
     topics: topicsToDelete,
+    timeout: 295000,
   });
 
   await admin.disconnect();


### PR DESCRIPTION
## Purpose

This is a bug fix against the deleteTopics refactor work.  It increases our kafkajs deleteTopics call's timeout to about five minutes.

#### Linked Issues to Close

None

## Approach

While we had been setting the kafka client's requestTimeout, there's a separate timeout field for admin.deleteTopics, per the docs.  This needs to be set to a higher-than-default value in our case, as we are sometimes deleting hundreds of topics in a single call (ksqldb).

## Assorted Notes/Considerations/Learning

None