### PR TITLE
feat(cloudwatch-metrics): add ecs cpu and memory alarms

### DIFF
--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -520,7 +520,7 @@ resources:
     ConnectorECSCpuAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
-        AlarmName: ${self:service}-${sls:stage}-CPUUtilization
+        AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-CPUUtilization
         AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
         Namespace: AWS/ECS
         MetricName: "CPUUtilization"
@@ -548,7 +548,7 @@ resources:
     ConnectorECSMemoryAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
-        AlarmName: ${self:service}-${sls:stage}-MemoryUtilization
+        AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-MemoryUtilization
         AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
         Namespace: AWS/ECS
         MetricName: "MemoryUtilization"

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -517,6 +517,62 @@ resources:
         MetricName: ConnectorLogsWarnCount
         Namespace: ${self:service}-${sls:stage}/Connector/WARNS
         Statistic: Sum
+    ConnectorECSCpuAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-CPUUtilization
+        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "CPUUtilization"
+        Dimensions:
+          - Name: ClusterName
+            Value: !Ref KafkaConnectCluster
+          - Name: ServiceName
+            Value:
+              !Select [
+                2,
+                !Split [
+                  "/",
+                  !Select [5, !Split [":", !Ref KafkaConnectService]],
+                ],
+              ]
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${param:ecsFailureTopicArn}
+        OKActions:
+          - ${param:ecsFailureTopicArn}
+    ConnectorECSMemoryAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-MemoryUtilization
+        AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "MemoryUtilization"
+        Dimensions:
+          - Name: ClusterName
+            Value: !Ref KafkaConnectCluster
+          - Name: ServiceName
+            Value:
+              !Select [
+                2,
+                !Split [
+                  "/",
+                  !Select [5, !Split [":", !Ref KafkaConnectService]],
+                ],
+              ]
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${param:ecsFailureTopicArn}
+        OKActions:
+          - ${param:ecsFailureTopicArn}
 
   Outputs:
     KafkaConnectWorkerSecurityGroupId:

--- a/src/services/connector/serverless.yml
+++ b/src/services/connector/serverless.yml
@@ -523,23 +523,16 @@ resources:
         AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-CPUUtilization
         AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
         Namespace: AWS/ECS
-        MetricName: "CPUUtilization"
+        MetricName: CPUUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref KafkaConnectCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split [
-                  "/",
-                  !Select [5, !Split [":", !Ref KafkaConnectService]],
-                ],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
+            Value: !GetAtt KafkaConnectService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
         ComparisonOperator: "GreaterThanOrEqualToThreshold"
         AlarmActions:
           - ${param:ecsFailureTopicArn}
@@ -551,24 +544,17 @@ resources:
         AlarmName: ${self:service}-${sls:stage}-KafkaConnectService-MemoryUtilization
         AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
         Namespace: AWS/ECS
-        MetricName: "MemoryUtilization"
+        MetricName: MemoryUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref KafkaConnectCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split [
-                  "/",
-                  !Select [5, !Split [":", !Ref KafkaConnectService]],
-                ],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
-        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+            Value: !GetAtt KafkaConnectService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
+        ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:ecsFailureTopicArn}
         OKActions:

--- a/src/services/ksqldb/serverless.yml
+++ b/src/services/ksqldb/serverless.yml
@@ -427,24 +427,17 @@ resources:
         AlarmName: ${self:service}-${sls:stage}-ksqldbHeadlessService-CPUUtilization
         AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
         Namespace: AWS/ECS
-        MetricName: "CPUUtilization"
+        MetricName: CPUUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref ksqldbHeadlessCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split [
-                  "/",
-                  !Select [5, !Split [":", !Ref ksqldbHeadlessService]],
-                ],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
-        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+            Value: !GetAtt ksqldbHeadlessService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
+        ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:ecsFailureTopicArn}
         OKActions:
@@ -455,24 +448,17 @@ resources:
         AlarmName: ${self:service}-${sls:stage}-ksqldbHeadlessService-MemoryUtilization
         AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
         Namespace: AWS/ECS
-        MetricName: "MemoryUtilization"
+        MetricName: MemoryUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref ksqldbHeadlessCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split [
-                  "/",
-                  !Select [5, !Split [":", !Ref ksqldbHeadlessService]],
-                ],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
-        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+            Value: !GetAtt ksqldbHeadlessService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
+        ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:ecsFailureTopicArn}
         OKActions:
@@ -483,21 +469,17 @@ resources:
         AlarmName: ${self:service}-${sls:stage}-ksqldbIntService-CPUUtilization
         AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
         Namespace: AWS/ECS
-        MetricName: "CPUUtilization"
+        MetricName: CPUUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref ksqldbHeadlessCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split ["/", !Select [5, !Split [":", !Ref ksqldbIntService]]],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
-        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+            Value: !GetAtt ksqldbIntService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
+        ComparisonOperator: GreaterThanOrEqualToThreshold
         AlarmActions:
           - ${param:ecsFailureTopicArn}
         OKActions:
@@ -508,20 +490,16 @@ resources:
         AlarmName: ${self:service}-${sls:stage}-ksqldbIntService-MemoryUtilization
         AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
         Namespace: AWS/ECS
-        MetricName: "MemoryUtilization"
+        MetricName: MemoryUtilization
         Dimensions:
           - Name: ClusterName
             Value: !Ref ksqldbHeadlessCluster
           - Name: ServiceName
-            Value:
-              !Select [
-                2,
-                !Split ["/", !Select [5, !Split [":", !Ref ksqldbIntService]]],
-              ]
-        Statistic: "Average"
-        Period: "300"
-        EvaluationPeriods: "2"
-        Threshold: "75"
+            Value: !GetAtt ksqldbIntService.Name
+        Statistic: Average
+        Period: 60
+        EvaluationPeriods: 2
+        Threshold: 75
         ComparisonOperator: "GreaterThanOrEqualToThreshold"
         AlarmActions:
           - ${param:ecsFailureTopicArn}

--- a/src/services/ksqldb/serverless.yml
+++ b/src/services/ksqldb/serverless.yml
@@ -420,6 +420,113 @@ resources:
           - ${param:topicNamespace}aws.ksqldb.seatool.tld*
           - _confluent-ksql-${param:topicNamespace}${self:service}-*
           - ${param:topicNamespace}${self:service}*
+
+    ksqldbHeadlessServiceECSCpuAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-ksqldbHeadlessService-CPUUtilization
+        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "CPUUtilization"
+        Dimensions:
+          - Name: ClusterName
+            Value: !Ref ksqldbHeadlessCluster
+          - Name: ServiceName
+            Value:
+              !Select [
+                2,
+                !Split [
+                  "/",
+                  !Select [5, !Split [":", !Ref ksqldbHeadlessService]],
+                ],
+              ]
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${param:ecsFailureTopicArn}
+        OKActions:
+          - ${param:ecsFailureTopicArn}
+    ksqldbHeadlessServiceECSMemoryAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-ksqldbHeadlessService-MemoryUtilization
+        AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "MemoryUtilization"
+        Dimensions:
+          - Name: ClusterName
+            Value: !Ref ksqldbHeadlessCluster
+          - Name: ServiceName
+            Value:
+              !Select [
+                2,
+                !Split [
+                  "/",
+                  !Select [5, !Split [":", !Ref ksqldbHeadlessService]],
+                ],
+              ]
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${param:ecsFailureTopicArn}
+        OKActions:
+          - ${param:ecsFailureTopicArn}
+    ksqldbIntServiceECSCpuAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-ksqldbIntService-CPUUtilization
+        AlarmDescription: "Trigger an alarm when the CPU utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "CPUUtilization"
+        Dimensions:
+          - Name: ClusterName
+            Value: !Ref ksqldbHeadlessCluster
+          - Name: ServiceName
+            Value:
+              !Select [
+                2,
+                !Split ["/", !Select [5, !Split [":", !Ref ksqldbIntService]]],
+              ]
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${param:ecsFailureTopicArn}
+        OKActions:
+          - ${param:ecsFailureTopicArn}
+    ksqldbIntServiceECSMemoryAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-ksqldbIntService-MemoryUtilization
+        AlarmDescription: "Trigger an alarm when the Memory utilization reaches 75%"
+        Namespace: AWS/ECS
+        MetricName: "MemoryUtilization"
+        Dimensions:
+          - Name: ClusterName
+            Value: !Ref ksqldbHeadlessCluster
+          - Name: ServiceName
+            Value:
+              !Select [
+                2,
+                !Split ["/", !Select [5, !Split [":", !Ref ksqldbIntService]]],
+              ]
+        Statistic: "Average"
+        Period: "300"
+        EvaluationPeriods: "2"
+        Threshold: "75"
+        ComparisonOperator: "GreaterThanOrEqualToThreshold"
+        AlarmActions:
+          - ${param:ecsFailureTopicArn}
+        OKActions:
+          - ${param:ecsFailureTopicArn}
     LambdaSecurityGroup:
       Type: AWS::EC2::SecurityGroup
       Properties:


### PR DESCRIPTION
## Purpose

This PR is to configure CPUUtilsation and MemoryUtilisation cloudwatch alarms for all ecs services. The alarms is set to trigger on 75% utilisation threshold hold. The alarms are configured to send a notification to the alerts' service SNS topic.

#### Linked Issues to Close
https://qmacbis.atlassian.net/browse/OY2-23316 

## Approach
Alarms have been created for all ecs clusters and services running in the clusters. Memory and cpu metrics are reported out of the box by AWS. We are only creating the cloudwatch alarms to send notifications to the alert sns topic when specific thresholds are met.

## Assorted Notes/Considerations/Learning
The configuration parameters to be set for the cloudformation template can be found here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html#available_cloudwatch_metrics
