### PR TITLE
fix: downsize ksqlthree cpu and memory usage per profesormac

### DIFF
--- a/src/services/ksqlthree/serverless.yml
+++ b/src/services/ksqlthree/serverless.yml
@@ -68,22 +68,22 @@ params:
     rocksdbCache: 4294967296
     topicNamespace: ""
   val:
-    cpu: 8192
-    heap: "-Xms14G -Xmx14G"
-    memory: 32768
-    rocksdbCache: 10737418240
+    cpu: 2048
+    heap: "-Xms4G -Xmx4G"
+    memory: 11264
+    rocksdbCache: 4294967296
     topicNamespace: ""
   production:
-    cpu: 8192
-    heap: "-Xms14G -Xmx14G"
-    memory: 32768
-    rocksdbCache: 10737418240
+    cpu: 2048
+    heap: "-Xms4G -Xmx4G"
+    memory: 12288
+    rocksdbCache: 4294967296
     topicNamespace: ""
   default:
     cpu: 2048
     heap: "-Xms4G -Xmx4G"
-    memory: 8192
-    rocksdbCache: 2147483648
+    memory: 12288
+    rocksdbCache: 4294967296
     topicNamespace: --${self:custom.project}--${sls:stage}--
 
 layers:

--- a/src/services/ksqlthree/serverless.yml
+++ b/src/services/ksqlthree/serverless.yml
@@ -62,10 +62,10 @@ custom:
 
 params:
   master:
-    cpu: 8192
-    heap: "-Xms14G -Xmx14G"
-    memory: 32768
-    rocksdbCache: 10737418240
+    cpu: 2048
+    heap: "-Xms4G -Xmx4G"
+    memory: 11264
+    rocksdbCache: 4294967296
     topicNamespace: ""
   val:
     cpu: 8192


### PR DESCRIPTION
## Purpose

To optimize cpu and memory usage for ksqlthree service. 

#### Linked Issues to Close
Production - https://jiraent.cms.gov/browse/MACFC-1724
Val - https://jiraent.cms.gov/browse/MACFC-1161
Master - https://jiraent.cms.gov/browse/MACFC-1164


## Approach

As per professor mac recommendation for the cpu and memory usage, I adjusted the cpu, memory, rocksdb, and heap sizes.

## Assorted Notes/Considerations/Learning

_List any other information that you think is important... a post-merge activity, someone to notify, what you learned, etc._
